### PR TITLE
Link license to repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,8 @@ The examples folder contains Jupyter Notebooks with some of our developing think
 
 ## License
 
-[![License: UNLICENSE](https://unlicense.org)
+[License: UNLICENSE](https://github.com/TrashBirdEcology/pymodelcat/blob/master/LICENSE)
+
 
 ## Acknowledgments
 


### PR DESCRIPTION
The license link should lead to your repo's license. UNLICENSE is well-described automatically by GitHub, and provides links to further information.